### PR TITLE
removed peer dependencies to avoid legacy message

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
       "**/__tests__/*.spec.(ts|tsx|js)"
     ]
   },
-  "peerDependencies": {
-    "react": "^15.x || ^16.x || ^17.x"
-  },
   "files": [
     "es",
     "lib",


### PR DESCRIPTION
Cleaning up warning that prevent `npm install` from working